### PR TITLE
Fix navigation

### DIFF
--- a/app2/auth/src/bootstrap.js
+++ b/app2/auth/src/bootstrap.js
@@ -5,9 +5,13 @@ import { createMemoryHistory, createBrowserHistory } from "history";
 import App from "./App";
 
 // Mount function to start up the app
-const mount = (el, { onNavigate, defaultHistory }) => {
+const mount = (el, { onNavigate, defaultHistory, initialPath }) => {
 	// Either use browser history or memory history based on mode the app is running in
-	const history = defaultHistory || createMemoryHistory();
+	const history =
+		defaultHistory ||
+		createMemoryHistory({
+			initialEntries: [initialPath],
+		});
 
 	if (onNavigate) {
 		history.listen(onNavigate);

--- a/app2/container/config/webpack.dev.js
+++ b/app2/container/config/webpack.dev.js
@@ -12,9 +12,7 @@ const devConfig = {
 	},
 	devServer: {
 		port: DEV_PORT,
-		historyApiFallback: {
-			index: "index.html",
-		},
+		historyApiFallback: true,
 	},
 	plugins: [
 		new ModuleFederationPlugin({

--- a/app2/container/src/components/AuthApp.js
+++ b/app2/container/src/components/AuthApp.js
@@ -9,6 +9,7 @@ function AuthApp() {
 
 	useEffect(() => {
 		const { onParentNavigate } = mount(ref.current, {
+			initialPath: history.location.pathname,
 			onNavigate: ({ pathname: nextPathname }) => {
 				const { pathname } = history.location;
 

--- a/app2/container/src/components/MarketingApp.js
+++ b/app2/container/src/components/MarketingApp.js
@@ -9,6 +9,7 @@ function MarketingApp() {
 
 	useEffect(() => {
 		const { onParentNavigate } = mount(ref.current, {
+			initialPath: history.location.pathname,
 			onNavigate: ({ pathname: nextPathname }) => {
 				const { pathname } = history.location;
 

--- a/app2/marketing/src/bootstrap.js
+++ b/app2/marketing/src/bootstrap.js
@@ -5,9 +5,13 @@ import { createMemoryHistory, createBrowserHistory } from "history";
 import App from "./App";
 
 // Mount function to start up the app
-const mount = (el, { onNavigate, defaultHistory }) => {
+const mount = (el, { onNavigate, defaultHistory, initialPath }) => {
 	// Either use browser history or memory history based on mode the app is running in
-	const history = defaultHistory || createMemoryHistory();
+	const history =
+		defaultHistory ||
+		createMemoryHistory({
+			initialEntries: [initialPath],
+		});
 
 	if (onNavigate) {
 		history.listen(onNavigate);


### PR DESCRIPTION
Add the initial path for sub-apps passed down from Container in order to sync the memory history object with Container's browser history.
Fix Container's webpack dev config where when reloading a page while the URL is showing a URL for sub-app there would be a 404 for getting that path.